### PR TITLE
fix azurecli user token support

### DIFF
--- a/auth/wrapper.go
+++ b/auth/wrapper.go
@@ -119,8 +119,8 @@ func (a *AuthorizerWrapper) Token() (*oauth2.Token, error) {
 	var adalToken adal.Token
 	if spToken, ok := tokenProviders[0].(ServicePrincipalToken); ok && spToken != nil {
 		adalToken = spToken.Token()
-	} else if spToken, ok := tokenProviders[0].(*adal.Token); ok && spToken != nil {
-		adalToken = *spToken
+	} else if token, ok := tokenProviders[0].(*adal.Token); ok && token != nil {
+		adalToken = *token
 	}
 	if adalToken.AccessToken == "" {
 		return nil, fmt.Errorf("could not obtain access token from token provider")

--- a/auth/wrapper.go
+++ b/auth/wrapper.go
@@ -119,6 +119,8 @@ func (a *AuthorizerWrapper) Token() (*oauth2.Token, error) {
 	var adalToken adal.Token
 	if spToken, ok := tokenProviders[0].(ServicePrincipalToken); ok && spToken != nil {
 		adalToken = spToken.Token()
+	} else if spToken, ok := tokenProviders[0].(*adal.Token); ok && spToken != nil {
+		adalToken = *spToken
 	}
 	if adalToken.AccessToken == "" {
 		return nil, fmt.Errorf("could not obtain access token from token provider")


### PR DESCRIPTION
token from a logged in user via azurecli was not properly used and error `could not obtain access token from token provider` as returned

Signed-off-by: Markus Blaschke <mblaschke82@gmail.com>